### PR TITLE
[ci skip] adding user @bandersen23

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @moorepants
+* @bandersen23

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @moorepants
-* @bandersen23
+* @bandersen23 @moorepants

--- a/README.md
+++ b/README.md
@@ -117,5 +117,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@bandersen23](https://github.com/bandersen23/)
 * [@moorepants](https://github.com/moorepants/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,4 +50,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - bandersen23
     - moorepants


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @bandersen23 as instructed in #94.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #94