### PR TITLE
Dash 2.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,6 @@ test:
     - dash.dcc
     - dash.html
     - dash.dash_table
-    - dash.callback
 
 about:
   home: https://plot.ly/dash

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,20 +18,15 @@ build:
 
 requirements:
   host:
-    - python ==2.7.*|>=3.3
+    - python >=3.6
     - setuptools
     - pip
   run:
-    - python ==2.7.*|>=3.3
-    - pyyaml >=5.1.1
+    - python >=3.6
+    - setuptools
     - flask >=1.0.4
     - flask-compress
-    - plotly
-    - dash-renderer ==1.9.1
-    - dash-core-components ==1.17.1
-    - dash-html-components ==1.1.4
-    - dash-table ==4.12.0
-    - future
+    - plotly >=5.0.0
 
 test:
   imports:
@@ -39,6 +34,10 @@ test:
     - dash.dependencies
     - dash.exceptions
     - dash.resources
+    - dash.dcc
+    - dash.html
+    - dash.dash_table
+    - dash.callback
 
 about:
   home: https://plot.ly/dash

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dash" %}
-{% set version = "1.21.0" %}
-{% set sha256 = "8b03a53e4f7a5f3eded8af099ff54d9981f7879d22d74c7970b9a27c8f698ebb" %}
+{% set version = "2.0.0" %}
+{% set sha256 = "29277c24e2f795b069cb102ce1ab0cd3ad5cf9d3b4fd16c03da9671a5eea28a4" %}
 
 package:
   name: {{ name|lower }}
@@ -32,7 +32,7 @@ requirements:
     - dash-html-components ==1.1.4
     - dash-table ==4.12.0
     - future
-    
+
 test:
   imports:
     - dash.dash


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Despite `dash-html-components`, `dash-core-components`, and `dash-table` being listed in the setup.py for dash, I removed them as they aren't needed due to the packages being wrapped into 2.0. I defer to you @moorepants whether that is acceptable. 

Those new packages now require dash 2.0 to run as they simply import from dash and raise a warning saying to use dash instead. That being said, I am updating those feedstocks as well, but they require dash now, so the directions in #89 don't quite match for this version.

I propose we merge `dash 2.0.0` into conda-forge, and then merge the `dash-*-components` packages. Thoughts @moorepants? Happy to change these as well.