### PR TITLE
Removed the upper pins for Flask and Werkzeug.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,8 @@ requirements:
   run:
     - python >=3.6
     - setuptools
-    - flask >=1.0.4, <2.3.0
-    - werkzeug <2.3.0
+    - flask >=1.0.4
+    - werkzeug
     - plotly >=5.0.0
     - typing-extensions >=4.1.1
     - requests


### PR DESCRIPTION
Upper pins make it very difficult or even impossible to manage conda environments and Dash has unwisely added them upstream. In this case, we should ensure the conda packages work smoothly within the conda ecosystem and not adopt these upper pins in the feedstock.

As mentioned here https://github.com/conda-forge/dash-feedstock/pull/129#issuecomment-1576382853

"I would rather we see how it goes without the upper pins. If we starting getting bug reports on it, then we can assess." -- moorepants

We have not received any bug reports, so I am removing the upper pins that were added without review in:

263e67dace9c150c95bf8aeca124f755e9b0ac11

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
