### PR TITLE
Update to match requires-install

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - nest-asyncio
     - dash-html-components >=2.0.0
     - dash-core-components >=2.0.0
-    - dash_table >=5.0.0
+    - dash-table >=5.0.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - retrying
     - ansi2html
     - nest-asyncio
+  run_constrained:
     - dash-html-components >=2.0.0
     - dash-core-components >=2.0.0
     - dash-table >=5.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - werkzeug <2.3.0
     - plotly >=5.0.0
     - importlib-metadata >=4.8.3  #python_version<"3.7"
-    - contextvars==2.4  #python_version<"3.7"
+    - contextvars >=2.4  #python_version<"3.7"
     - typing-extensions >=4.1.1
     - requests
     - retrying

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 
@@ -24,15 +24,16 @@ requirements:
   run:
     - python >=3.6
     - setuptools
-    - flask >=1.0.4
-    - werkzeug
+    - flask >=1.0.4,<2.3.0
+    - werkzeug <2.3.0
     - plotly >=5.0.0
+    - importlib-metadata >=4.8.3  #python_version<"3.7"
+    - contextvars==2.4  #python_version<"3.7"
     - typing-extensions >=4.1.1
     - requests
     - retrying
     - ansi2html
     - nest-asyncio
-  run_constrained:
     - dash-html-components >=2.0.0
     - dash-core-components >=2.0.0
     - dash_table >=5.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - werkzeug <2.3.0
     - plotly >=5.0.0
     - importlib-metadata >=4.8.3  #python_version<"3.7"
-    - contextvars >=2.4  #python_version<"3.7"
     - typing-extensions >=4.1.1
     - requests
     - retrying


### PR DESCRIPTION
https://github.com/plotly/dash/blob/v2.14.0/requires-install.txt

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I was running into issues using a pip environment for development and conda for packaging - and noticed that
1) there were packages in https://github.com/plotly/dash/blob/v2.14.0/requires-install.txt that were missing from the conda-recipe i.e. python <3.7 requires importlib-metadata & contextvars
2) there were to additional pins that were only in source / requirements i.e Flask>=1.0.4,<2.3.0  & Werkzeug<2.3.0
3) Since dash_html_components, dash_core_components and dash_table are in requires install - I suppose they should not be in run-constrained - but part of the run section. 
